### PR TITLE
Bug/commandline options being ignored

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,16 +5,28 @@ A web interface to Apache Cassandra with AngularJS and server-sent events.
 ## Installation
 
 ```bash
-$ gem install cassandra-web
+gem install cassandra-web
 ```
 
 ## Usage
 
+Run `cassandra-web -h` for help.
+
+### Quick Start
+
 ```bash
-$ cassandra-web
+cassandra-web
 ```
 
-Run `cassandra-web -h` for futher help.
+### Connect to a Cassandra Cluster requiring authentication
+
+```bash
+cassandra-web --hosts '10.0.2.2' --port '9042' --username 'cassweb' --password 'myPassword'
+```
+
+
+
+
 
 ## How it works
 
@@ -40,13 +52,13 @@ The web server, Thin, used by `cassandra-web` is asynchronous and uses only a si
 
 Cassandra web is possible because of the following awesome technologies (in no particular order):
 
-  * [Apache Cassandra](http://cassandra.apache.org/)
-  * [DataStax Ruby Driver for Apache Cassandra](http://datastax.github.io/ruby-driver/)
-  * [Sinatra](https://github.com/sinatra/sinatra)
-  * [AngularJS](https://angularjs.org/)
-  * [Twitter Bootstrap](http://getbootstrap.com/)
-  * [Thin](http://code.macournoyer.com/thin/)
-  * [Server Sent Events](http://www.w3.org/TR/2012/WD-eventsource-20120426/)
-  * [PrismJS](http://prismjs.com/)
-  * [CodeMirror](http://codemirror.net/)
-  * and many others...
+* [Apache Cassandra](http://cassandra.apache.org/)
+* [DataStax Ruby Driver for Apache Cassandra](http://datastax.github.io/ruby-driver/)
+    * [Sinatra](https://github.com/sinatra/sinatra)
+    * [AngularJS](https://angularjs.org/)
+    * [Twitter Bootstrap](http://getbootstrap.com/)
+    * [Thin](http://code.macournoyer.com/thin/)
+    * [Server Sent Events](http://www.w3.org/TR/2012/WD-eventsource-20120426/)
+    * [PrismJS](http://prismjs.com/)
+    * [CodeMirror](http://codemirror.net/)
+    * and many others...

--- a/app/public/html/index.html
+++ b/app/public/html/index.html
@@ -28,7 +28,7 @@
   </dl>
 </div>
 <div>
-  <h2>Kespaces</h2>
+  <h2>Keyspaces</h2>
   <dl>
     <dt ng-repeat-start="keyspace in cluster.keyspaces">
       <a href="/{{keyspace.name}}">{{keyspace.name}}</a>

--- a/bin/cassandra-web
+++ b/bin/cassandra-web
@@ -49,7 +49,8 @@ class CLI
 
     @options.each do |name, value|
       value = case name
-      when :port, :username, :password # skip as is
+      when :port, :username, :password
+        value # return the value as is without modification
       when :hosts
         value.split(',').map!(&:strip)
       when :compression


### PR DESCRIPTION

- Updated the **readme** to include an example with a username/password and host.
- Fixed a 'kespace' spelling mistake in **index.html**
- Fixed **cassandra-web** that was ignoring username, password, and port options when passed.